### PR TITLE
fix: configure sync-docs workflow to only run on main branch

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -1,6 +1,8 @@
 name: Auto-Sync Documentation
 on:
   push:
+    branches:
+      - main # Only run on main branch after merge, not on PR branches
     paths:
       - ".agent/**"
       - "apps/site/src/scripts/sync-agent-docs.js"


### PR DESCRIPTION
The workflow was trying to push to the protected main branch when triggered by PR pushes, causing failures. Now it only runs after merge to main, where it can successfully sync documentation.

This prevents the 'protected branch hook declined' error while still maintaining automatic documentation sync after merges.

## What does this PR do?

Describe your changes here.

Fixes #

## Checklist

- [ ] I tested my changes
- [ ] I reviewed my own code